### PR TITLE
Fix #22. Improved verification that checks whether SSL is in use.

### DIFF
--- a/multiple-domain/MultipleDomain.php
+++ b/multiple-domain/MultipleDomain.php
@@ -344,7 +344,7 @@ class MultipleDomain
     public function addHrefLangHeader()
     {
         $uri = $_SERVER['REQUEST_URI'];
-        $protocol = !isset($_SERVER['HTTPS']) || 'off' == $_SERVER['HTTPS'] ? 'http://' : 'https://';
+        $protocol = empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] === 'off' ? 'http://' : 'https://';
         $this->outputHrefLangHeader($protocol . $this->originalDomain . $uri);
 
         foreach ($this->domains as $domain => $values) {


### PR DESCRIPTION
This PR fixes and error mentioned on #22. URLs were always redirected to HTTPS, even when HTTP is in use. This shouldn't be this plugin's responsibility.