### PR TITLE
Replacing $_SERVER['REQUEST_URI'] to avoid XSS atacks

### DIFF
--- a/multiple-domain/MultipleDomain.php
+++ b/multiple-domain/MultipleDomain.php
@@ -380,7 +380,14 @@ class MultipleDomain
      */
     public function addHrefLangHeader()
     {
-        $uri = $_SERVER['REQUEST_URI'];
+        /**
+         * The WP class instance.
+         *
+         * @var WP
+         */
+        global $wp;
+
+        $uri = add_query_arg([], $wp->request);
         $protocol = empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] === 'off' ? 'http://' : 'https://';
         $this->outputHrefLangHeader($protocol . $this->originalDomain . $uri);
 


### PR DESCRIPTION
This PR fixes #28 by replacing `$_SERVER['REQUEST_URI']` with a safer alternative. It now uses Wordpress functions to get the current URI.