### PR TITLE
Fix #34. Added a leading slash to hreflang's URI.

### DIFF
--- a/multiple-domain/MultipleDomain.php
+++ b/multiple-domain/MultipleDomain.php
@@ -387,7 +387,7 @@ class MultipleDomain
          */
         global $wp;
 
-        $uri = add_query_arg([], $wp->request);
+        $uri = '/' . ltrim(add_query_arg([], $wp->request), '/');
         $protocol = empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] === 'off' ? 'http://' : 'https://';
         $this->outputHrefLangHeader($protocol . $this->originalDomain . $uri);
 


### PR DESCRIPTION
This PR fixes a bug reported on WP.org support forum. The `hreflang` attribute of `alternate` meta tag was missing a slash between the host and the URI.