### PR TITLE
Fixed regular expression used in domain replacement

### DIFF
--- a/multiple-domain/MultipleDomain.php
+++ b/multiple-domain/MultipleDomain.php
@@ -800,7 +800,7 @@ class MultipleDomain
     private function replaceDomain($domain, $content)
     {
         if (array_key_exists($domain, $this->domains)) {
-            $regex = '/(https?):\/\/' . preg_quote($domain, '/') . '([^a-z0-9\.\-:]*)/i';
+            $regex = '/(https?):\/\/' . preg_quote($domain, '/') . '(?![^a-z0-9.\-:])/i';
             $protocol = $this->getDomainProtocol($this->domain);
             $replace = ($protocol === 'auto' ? '${1}' : $protocol) . '://' . $this->domain . '${2}';
             $content = preg_replace($regex, $replace, $content);


### PR DESCRIPTION
This PR introduces a fix for the domain replacement regex. The bug was wrongly replacing domains and causing URLs like `http://domain.com.au.au` where both `domain.com` and `domain.com.au` were added to the plugin settings.

Fixes #59 