### PR TITLE
Fix memory usage + Other minor changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Since `0.7.1` this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+* Low memory option. ([#45])
+
 ### Fixed
 
 * Fixed variable names starting with `MULTPLE_`, changed to `MULTIPLE`.
@@ -293,6 +297,7 @@ e.g.
 [#55]: https://github.com/straube/multiple-domain/issues/55
 [#51]: https://github.com/straube/multiple-domain/issues/51
 [#50]: https://github.com/straube/multiple-domain/issues/50
+[#45]: https://github.com/straube/multiple-domain/issues/45
 [#44]: https://github.com/straube/multiple-domain/issues/44
 [#42]: https://github.com/straube/multiple-domain/issues/42
 [#39]: https://github.com/straube/multiple-domain/issues/39

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ Since `0.7.1` this project adheres to
 
 * Low memory option. ([#45])
 
+### Deprecated
+
+* Constants starting with `MULTPLE_` are now deprecated. They have a matching `MULTIPLE_` prefixed constant.
+
 ### Fixed
 
-* Fixed variable names starting with `MULTPLE_`, changed to `MULTIPLE`.
+* Fixed constants starting with `MULTPLE_`, changed to `MULTIPLE`.
 
 ## [1.0.1] - 2019-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Since `0.7.1` this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* Fixed variable names starting with `MULTPLE_`, changed to `MULTIPLE`.
+
 ## [1.0.1] - 2019-10-25
 
 ### Fixed
@@ -164,7 +170,7 @@ Since `0.7.1` this project adheres to
 
 ### Added
 
-* Added `MULTPLE_DOMAIN_DOMAIN_LANG` constant for theme/plugin customization. ([#20])
+* Added `MULTIPLE_DOMAIN_DOMAIN_LANG` constant for theme/plugin customization. ([#20])
 
 ### Changed
 
@@ -223,7 +229,7 @@ e.g.
 
 ### Added
 
-* `MULTPLE_DOMAIN_ORIGINAL_DOMAIN` constant to hold the original WP home domain.
+* `MULTIPLE_DOMAIN_ORIGINAL_DOMAIN` constant to hold the original WP home domain.
 * Allowing developers to create custom URL restriction logic through `multiple_domain_redirect` action.
 
 ### Changed
@@ -238,7 +244,7 @@ e.g.
 
 ### Added
 
-* `MULTPLE_DOMAIN_DOMAIN` constant for theme/plugin customization.
+* `MULTIPLE_DOMAIN_DOMAIN` constant for theme/plugin customization.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ WordPress installation since 3.0, you can find more info here: https://codex.wor
 
 **There is a way to add domain based logic to my themes?**
 
-Absolutely. You can use the `MULTPLE_DOMAIN_DOMAIN` and `MULTPLE_DOMAIN_ORIGINAL_DOMAIN` constants to get the current
+Absolutely. You can use the `MULTIPLE_DOMAIN_DOMAIN` and `MULTIPLE_DOMAIN_ORIGINAL_DOMAIN` constants to get the current
 and original domains. Just notice that since the value of the first one is checked against plugin settings, it may not
 reflect the actual domain in `HTTP_HOST` element from `$_SERVER` or user's browser. They also may include the host port
 when it's different than 80 (default HTTP port) or 443 (default HTTPS port).
@@ -53,7 +53,7 @@ https://github.com/straube/multiple-domain/issues/2 for an example on how to do 
 
 **Can I get the language associated with the current domain?**
 
-Yes. You can use the `MULTPLE_DOMAIN_DOMAIN_LANG` constant to get the language associated with the current domain. Keep
+Yes. You can use the `MULTIPLE_DOMAIN_DOMAIN_LANG` constant to get the language associated with the current domain. Keep
 in mind the value in this constant doesn't necessarily reflect the actual user language or locale. This is just the
 language set in the plugin config. Also notice the language may be `null`.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ and original domains. Just notice that since the value of the first one is check
 reflect the actual domain in `HTTP_HOST` element from `$_SERVER` or user's browser. They also may include the host port
 when it's different than 80 (default HTTP port) or 443 (default HTTPS port).
 
+**Notice**: in prior versions these constants were wrongly prefixed with `MULTPLE_`, missing the "I". The old constants
+are now deprecated. They still available for backcompat but will be removed in future releases.
+
 **Can I create a custom access restriction logic for each domain?**
 
 Yes. You can use the `multiple_domain_redirect` action to do that. Please check
@@ -56,6 +59,9 @@ https://github.com/straube/multiple-domain/issues/2 for an example on how to do 
 Yes. You can use the `MULTIPLE_DOMAIN_DOMAIN_LANG` constant to get the language associated with the current domain. Keep
 in mind the value in this constant doesn't necessarily reflect the actual user language or locale. This is just the
 language set in the plugin config. Also notice the language may be `null`.
+
+**Notice**: in prior versions these constants were wrongly prefixed with `MULTPLE_`, missing the "I". The old constants
+are now deprecated. They still available for backcompat but will be removed in future releases.
 
 **Can I show the current domain in the content of posts or pages?**
 

--- a/multiple-domain/MultipleDomain.php
+++ b/multiple-domain/MultipleDomain.php
@@ -799,6 +799,9 @@ class MultipleDomain
      */
     private function replaceDomain($domain, $content)
     {
+        if (MULTIPLE_DOMAIN_LOW_MEMORY) {
+            return $this->replaceDomainUsingLessMemory($domain, $content);
+        }
         if (array_key_exists($domain, $this->domains)) {
             $regex = '/(https?):\/\/' . preg_quote($domain, '/') . '(?![a-z0-9.\-:])/i';
             $protocol = $this->getDomainProtocol($this->domain);
@@ -825,7 +828,7 @@ class MultipleDomain
             $regex = '(https?):\/\/' . preg_quote($domain, '/') . '(?![a-z0-9.\-:])';
             $protocol = $this->getDomainProtocol($this->domain);
             $replace = ($protocol === 'auto' ? '\\1' : $protocol) . '://' . $this->domain;
-            $content = preg_replace($regex, $replace, $content);
+            $content = mb_eregi_replace($regex, $replace, $content);
         }
         return $content;
     }

--- a/multiple-domain/MultipleDomain.php
+++ b/multiple-domain/MultipleDomain.php
@@ -800,9 +800,9 @@ class MultipleDomain
     private function replaceDomain($domain, $content)
     {
         if (array_key_exists($domain, $this->domains)) {
-            $regex = '/(https?):\/\/' . preg_quote($domain, '/') . '(?![^a-z0-9.\-:])/i';
+            $regex = '/(https?):\/\/' . preg_quote($domain, '/') . '(?![a-z0-9.\-:])/i';
             $protocol = $this->getDomainProtocol($this->domain);
-            $replace = ($protocol === 'auto' ? '${1}' : $protocol) . '://' . $this->domain . '${2}';
+            $replace = ($protocol === 'auto' ? '${1}' : $protocol) . '://' . $this->domain;
             $content = preg_replace($regex, $replace, $content);
         }
         return $content;

--- a/multiple-domain/MultipleDomain.php
+++ b/multiple-domain/MultipleDomain.php
@@ -137,7 +137,7 @@ class MultipleDomain
          * plugin path as its keys. We'll use this path to move Multiple Domain
          * to the first position in that array.
          */
-        $path = str_replace(WP_PLUGIN_DIR . '/', '', MULTPLE_DOMAIN_PLUGIN);
+        $path = str_replace(WP_PLUGIN_DIR . '/', '', MULTIPLE_DOMAIN_PLUGIN);
         $plugins = get_option('active_plugins');
 
         if (empty($plugins)) {
@@ -680,7 +680,7 @@ class MultipleDomain
      */
     public function loaded()
     {
-        $path = dirname(plugin_basename(MULTPLE_DOMAIN_PLUGIN)) . '/languages/';
+        $path = dirname(plugin_basename(MULTIPLE_DOMAIN_PLUGIN)) . '/languages/';
         load_plugin_textdomain('multiple-domain', false, $path);
     }
 

--- a/multiple-domain/MultipleDomain.php
+++ b/multiple-domain/MultipleDomain.php
@@ -809,6 +809,28 @@ class MultipleDomain
     }
 
     /**
+     * Replaces the domain using less memory.
+     *
+     * This function does the same as `replaceDoamin`, however it uses
+     * `mb_eregi_replace` instead of `preg_replace` for less memory consumption.
+     * On the other hand, it takes more time to execute.
+     *
+     * @param  string $domain The domain to replace.
+     * @param  string $content The content that will have the domain replaced.
+     * @return string The domain-replaced content.
+     */
+    private function replaceDomainUsingLessMemory($domain, $content)
+    {
+        if (array_key_exists($domain, $this->domains)) {
+            $regex = '(https?):\/\/' . preg_quote($domain, '/') . '(?![a-z0-9.\-:])';
+            $protocol = $this->getDomainProtocol($this->domain);
+            $replace = ($protocol === 'auto' ? '\\1' : $protocol) . '://' . $this->domain;
+            $content = preg_replace($regex, $replace, $content);
+        }
+        return $content;
+    }
+
+    /**
      * Parses the given URL to return only its domain.
      *
      * The server port may be included in the returning value depending on its

--- a/multiple-domain/MultipleDomainSettings.php
+++ b/multiple-domain/MultipleDomainSettings.php
@@ -57,7 +57,7 @@ class MultipleDomainSettings
      */
     private function hookFilters()
     {
-        add_filter('plugin_action_links_' . plugin_basename(MULTPLE_DOMAIN_PLUGIN), [ $this, 'actionLinks' ]);
+        add_filter('plugin_action_links_' . plugin_basename(MULTIPLE_DOMAIN_PLUGIN), [ $this, 'actionLinks' ]);
     }
 
     //
@@ -212,7 +212,7 @@ class MultipleDomainSettings
         if ($hook !== 'options-general.php') {
             return;
         }
-        $settingsPath = plugins_url('settings.js', MULTPLE_DOMAIN_PLUGIN);
+        $settingsPath = plugins_url('settings.js', MULTIPLE_DOMAIN_PLUGIN);
         wp_enqueue_script('multiple-domain-settings', $settingsPath, [ 'jquery' ], MultipleDomain::VERSION, true);
     }
 
@@ -306,7 +306,7 @@ class MultipleDomainSettings
     {
         $locales = [];
 
-        $handle = fopen(dirname(MULTPLE_DOMAIN_PLUGIN) . '/locales.csv', 'r');
+        $handle = fopen(dirname(MULTIPLE_DOMAIN_PLUGIN) . '/locales.csv', 'r');
         while (($row = fgetcsv($handle)) !== false) {
             $locales[$row[0]] = $row[1];
         }
@@ -326,7 +326,7 @@ class MultipleDomainSettings
      */
     private function loadView($name, $data = null)
     {
-        $path = sprintf('%s/views/%s.php', dirname(MULTPLE_DOMAIN_PLUGIN), $name);
+        $path = sprintf('%s/views/%s.php', dirname(MULTIPLE_DOMAIN_PLUGIN), $name);
         if (!is_file($path)) {
             return false;
         }

--- a/multiple-domain/multiple-domain.php
+++ b/multiple-domain/multiple-domain.php
@@ -100,9 +100,9 @@ define('MULTIPLE_DOMAIN_DOMAIN_LANG', $domainLang);
 
 
 /**
- * Keeping back-compability with older versions.
+ * Keeping back compability with prior versions.
  *
- * This constant will be removed in a future version.
+ * This constant will be removed in a future release.
  *
  * @var string
  * @see MULTIPLE_DOMAIN_DOMAIN
@@ -112,9 +112,9 @@ define('MULTPLE_DOMAIN_DOMAIN', MULTIPLE_DOMAIN_DOMAIN);
 
 
 /**
- * Keeping back-compability with older versions.
+ * Keeping back compability with prior versions.
  *
- * This constant will be removed in a future version.
+ * This constant will be removed in a future release.
  *
  * @var string
  * @see MULTIPLE_DOMAIN_ORIGINAL_DOMAIN
@@ -124,9 +124,9 @@ define('MULTPLE_DOMAIN_ORIGINAL_DOMAIN', MULTIPLE_DOMAIN_ORIGINAL_DOMAIN);
 
 
 /**
- * Keeping back-compability with older versions.
+ * Keeping back compability with prior versions.
  *
- * This constant will be removed in a future version.
+ * This constant will be removed in a future release.
  *
  * @var string
  * @see MULTIPLE_DOMAIN_DOMAIN_LANG

--- a/multiple-domain/multiple-domain.php
+++ b/multiple-domain/multiple-domain.php
@@ -30,13 +30,13 @@ require 'MultipleDomainSettings.php';
  * @var   string
  * @since 0.8.3
  */
-define('MULTPLE_DOMAIN_PLUGIN', __FILE__);
+define('MULTIPLE_DOMAIN_PLUGIN', __FILE__);
 
 
 /*
  * Register the activation method.
  */
-register_activation_hook(MULTPLE_DOMAIN_PLUGIN, [ MultipleDomain::class, 'activate' ]);
+register_activation_hook(MULTIPLE_DOMAIN_PLUGIN, [ MultipleDomain::class, 'activate' ]);
 
 
 /*
@@ -59,7 +59,7 @@ $domainLang = $multipleDomain->getDomainLang();
  * @var   string
  * @since 0.2
  */
-define('MULTPLE_DOMAIN_DOMAIN', $domain);
+define('MULTIPLE_DOMAIN_DOMAIN', $domain);
 
 
 /**
@@ -68,7 +68,7 @@ define('MULTPLE_DOMAIN_DOMAIN', $domain);
  * @var   string
  * @since 0.3
  */
-define('MULTPLE_DOMAIN_ORIGINAL_DOMAIN', $originalDomain);
+define('MULTIPLE_DOMAIN_ORIGINAL_DOMAIN', $originalDomain);
 
 
 /**
@@ -82,4 +82,4 @@ define('MULTPLE_DOMAIN_ORIGINAL_DOMAIN', $originalDomain);
  * @var   string
  * @since 0.8
  */
-define('MULTPLE_DOMAIN_DOMAIN_LANG', $domainLang);
+define('MULTIPLE_DOMAIN_DOMAIN_LANG', $domainLang);

--- a/multiple-domain/multiple-domain.php
+++ b/multiple-domain/multiple-domain.php
@@ -97,3 +97,39 @@ define('MULTIPLE_DOMAIN_ORIGINAL_DOMAIN', $originalDomain);
  * @since 0.8
  */
 define('MULTIPLE_DOMAIN_DOMAIN_LANG', $domainLang);
+
+
+/**
+ * Keeping back-compability with older versions.
+ *
+ * This constant will be removed in a future version.
+ *
+ * @var string
+ * @see MULTIPLE_DOMAIN_DOMAIN
+ * @deprecated
+ */
+define('MULTPLE_DOMAIN_DOMAIN', MULTIPLE_DOMAIN_DOMAIN);
+
+
+/**
+ * Keeping back-compability with older versions.
+ *
+ * This constant will be removed in a future version.
+ *
+ * @var string
+ * @see MULTIPLE_DOMAIN_ORIGINAL_DOMAIN
+ * @deprecated
+ */
+define('MULTPLE_DOMAIN_ORIGINAL_DOMAIN', MULTIPLE_DOMAIN_ORIGINAL_DOMAIN);
+
+
+/**
+ * Keeping back-compability with older versions.
+ *
+ * This constant will be removed in a future version.
+ *
+ * @var string
+ * @see MULTIPLE_DOMAIN_DOMAIN_LANG
+ * @deprecated
+ */
+define('MULTPLE_DOMAIN_DOMAIN_LANG', MULTIPLE_DOMAIN_DOMAIN_LANG);

--- a/multiple-domain/multiple-domain.php
+++ b/multiple-domain/multiple-domain.php
@@ -32,6 +32,20 @@ require 'MultipleDomainSettings.php';
  */
 define('MULTIPLE_DOMAIN_PLUGIN', __FILE__);
 
+if (!defined('MULTIPLE_DOMAIN_LOW_MEMORY')) {
+
+    /**
+     * The low memory option.
+     *
+     * This option may be used where the site is throwing "allowed memory
+     * exhausted" errors. It will reduce the memory usage in domain replacements
+     * with the downside of a higher execution time.
+     *
+     * @var bool
+     */
+    define('MULTIPLE_DOMAIN_LOW_MEMORY', false);
+}
+
 
 /*
  * Register the activation method.

--- a/multiple-domain/readme.txt
+++ b/multiple-domain/readme.txt
@@ -63,7 +63,7 @@ WordPress installation since 3.0, you can find more info here: [https://codex.wo
 
 = There is a way to add domain based logic to my themes? =
 
-Absolutely. You can use the `MULTPLE_DOMAIN_DOMAIN` constant to get the current domain. Just notice that since this
+Absolutely. You can use the `MULTIPLE_DOMAIN_DOMAIN` constant to get the current domain. Just notice that since this
 value is checked against plugin settings, it may not reflect the actual domain in `HTTP_HOST` element from `$_SERVER` or
 user's browser. It also may include the host port when it's different than 80 (default HTTP port) or 443 (default HTTPS
 port).
@@ -75,7 +75,7 @@ https://github.com/straube/multiple-domain/issues/2 for an example on how to do 
 
 = Can I get the language associated with the current domain? =
 
-Yes. You can use the `MULTPLE_DOMAIN_DOMAIN_LANG` constant to get the language associated with the current domain. Keep
+Yes. You can use the `MULTIPLE_DOMAIN_DOMAIN_LANG` constant to get the language associated with the current domain. Keep
 in mind the value in this constant doesn't necessarily reflect the actual user language or locale. This is just the
 language set in the plugin config. Also notice the language may be `null`.
 
@@ -195,7 +195,7 @@ https://github.com/straube/multiple-domain/issues/51.
 * Moved `MultipleDomain` class to its own file.
 * Fix: #14 Remove `filter_input` from plugin.
 * Attempt to fix #22.
-* Added `MULTPLE_DOMAIN_DOMAIN_LANG` constant for theme/plugin customization. Fixes #20.
+* Added `MULTIPLE_DOMAIN_DOMAIN_LANG` constant for theme/plugin customization. Fixes #20.
 * Fix: #21 No 'Access-Control-Allow-Origin' header is present on the requested resource
 
 = 0.7.1 =
@@ -219,13 +219,13 @@ https://github.com/straube/multiple-domain/issues/51.
 
 = 0.3 =
 * Fixed bug when removing the port from current domain.
-* Added `MULTPLE_DOMAIN_ORIGINAL_DOMAIN` constant to hold the original WP home domain.
+* Added `MULTIPLE_DOMAIN_ORIGINAL_DOMAIN` constant to hold the original WP home domain.
 * Allowing developers to create custom URL restriction logic through `multiple_domain_redirect` action.
 * Improved settings interface.
 
 = 0.2 =
 * Improved port verification.
-* Added `MULTPLE_DOMAIN_DOMAIN` constant for theme/plugin customization.
+* Added `MULTIPLE_DOMAIN_DOMAIN` constant for theme/plugin customization.
 * And, last but not least, code refactoring.
 
 = 0.1 =

--- a/multiple-domain/readme.txt
+++ b/multiple-domain/readme.txt
@@ -59,14 +59,17 @@ No. You have to set additional domains, DNS, and everything else to use this plu
 = Can I have a different theme/content/plugins for each domain? =
 
 Nope. If you want a complex set up like this, you may be interested in WordPress Multisite. It's delivered with every
-WordPress installation since 3.0, you can find more info here: [https://codex.wordpress.org/Create_A_Network].
+WordPress installation since 3.0, you can find more info here: https://codex.wordpress.org/Create_A_Network.
 
 = There is a way to add domain based logic to my themes? =
 
-Absolutely. You can use the `MULTIPLE_DOMAIN_DOMAIN` constant to get the current domain. Just notice that since this
-value is checked against plugin settings, it may not reflect the actual domain in `HTTP_HOST` element from `$_SERVER` or
-user's browser. It also may include the host port when it's different than 80 (default HTTP port) or 443 (default HTTPS
-port).
+Absolutely. You can use the `MULTIPLE_DOMAIN_DOMAIN` and `MULTIPLE_DOMAIN_ORIGINAL_DOMAIN` constants to get the current
+and original domains. Just notice that since the value of the first one is checked against plugin settings, it may not
+reflect the actual domain in `HTTP_HOST` element from `$_SERVER` or user's browser. They also may include the host port
+when it's different than 80 (default HTTP port) or 443 (default HTTPS port).
+
+**Notice**: in prior versions these constants were wrongly prefixed with `MULTPLE_`, missing the "I". The old constants
+are now deprecated. They still available for backcompat but will be removed in future releases.
 
 = Can I create a custom access restriction logic for each domain? =
 
@@ -78,6 +81,9 @@ https://github.com/straube/multiple-domain/issues/2 for an example on how to do 
 Yes. You can use the `MULTIPLE_DOMAIN_DOMAIN_LANG` constant to get the language associated with the current domain. Keep
 in mind the value in this constant doesn't necessarily reflect the actual user language or locale. This is just the
 language set in the plugin config. Also notice the language may be `null`.
+
+**Notice**: in prior versions these constants were wrongly prefixed with `MULTPLE_`, missing the "I". The old constants
+are now deprecated. They still available for backcompat but will be removed in future releases.
 
 = Can I show the current domain in the content of posts or pages? =
 
@@ -91,11 +97,23 @@ Any domain you're site is served from must be added to the plugin configuration.
 domain where your WordPress was installed in must be added. You'll probably see some unexpected output when accessing
 the site from a non-mapped domain.
 
-= Can I disable hreflang tags output even for the original domain? =
+= Can I disable `hreflang` tags output even for the original domain? =
 
 Yes. You may notice that even if you don't set a language for any domain, you still get a default `hreflang` tag in
 your page head. To disable this behavior, follow the instructions from
 https://github.com/straube/multiple-domain/issues/51.
+
+= I locked myself out, and what am I doing now? =
+
+Under certain circumstances, in the case of a wrong configuration, you may not be able to log in to the admin area
+and your page will be redirected. In this case, there are two ways to solve this.
+
+1. Delete the plugin directory `wp-content/plugins/multiple-domain`. You should be able to do that from the hosting
+    panel, from an FTP client, or via SSH. The downside of this technique is that it won’t be possible to install the
+    plugin again since the configuration will still be in the database.
+2. Remove the plugin configuration from the database using the following SQL query `DELETE FROM {YOUR-PREFIX}_options
+    WHERE option_name LIKE 'multiple-domain-%'`; (Remember to replace the prefix from your own table name). This can be
+    done from the hosting panel when PHPMyAdmin is available or using a MySQL client.
 
 == Screenshots ==
 


### PR DESCRIPTION
This PR fixes the high memory usage issue.

It requires some config for the low memory usage mode to be enabled, adding the following line to your `wp-config.php` file:

```
define('MULTIPLE_DOMAIN_LOW_MEMORY', true);
```