### PR TITLE
Override WordPress built-in Canonical URL

### DIFF
--- a/multiple-domain/MultipleDomain.php
+++ b/multiple-domain/MultipleDomain.php
@@ -255,6 +255,9 @@ class MultipleDomain
 
         // Add body class based on domain
         add_filter('body_class', [ $this, 'addDomainBodyClass' ]);
+
+        // Stop WP built in Canonical URL if this plugin has 'Add canonical links' enabled
+        add_filter('get_canonical_url', [ $this, 'getCanonicalUrl' ]);
     }
 
     /**
@@ -897,5 +900,20 @@ class MultipleDomain
     {
         $url = htmlentities($url);
         printf('<link rel="canonical" href="%s" />', $url);
+    }
+
+    /**
+     * Filter override WordPress built-in canonical tag generation if using the this plugin's canonical tag feature
+     *
+     * @param $url
+     * @return string
+     */
+    public function getCanonicalUrl($url)
+    {
+        // If *not* using the plugin's canonical tags, then return this URL. Otherwise, don't
+        if (!$this->shouldAddCanonical()) {
+            return $url;
+        }
+        return '';
     }
 }


### PR DESCRIPTION
Not sure when it happened but WP is now generating it's own canonical URLs (wp-includes/link-template.php::rel_canonical() ~line:3810). This conflicts with this plugins generation of canonical.

This patch overrides the WP filter: 'get_canonical_url' to return nothing if 'Add canonical links' has been enabled.